### PR TITLE
Added +0.5 to sizer for measuring size of speech bubble

### DIFF
--- a/Source/Views/Cells/KUSChatMessageTableViewCell.m
+++ b/Source/Views/Cells/KUSChatMessageTableViewCell.m
@@ -131,7 +131,7 @@ static const CGFloat kTimestampTopPadding = 4.0;
 {
     CGFloat actualMaxWidth = MIN(kMaxBubbleWidth - kBubbleSidePadding * 2.0, maxWidth);
 
-    NSAttributedString *attributedString = [KUSText attributedStringFromText:text fontSize:[self fontSize]];
+    NSAttributedString *attributedString = [KUSText attributedStringFromText:text fontSize:[self fontSize]+0.5];
 
     CGSize maxSize = CGSizeMake(actualMaxWidth, 1000.0);
     CGRect boundingRect = [attributedString boundingRectWithSize:maxSize


### PR DESCRIPTION
# Overview

Had to add 0.5 to fontSize in order to correctly measure the size of a speech bubble. 

## Details

Looked through the docs/commits of the master Kustomer repo and found this little line tucked away. 

## Screenshots

none
